### PR TITLE
Add thermal control daemon for thermal control feature

### DIFF
--- a/sonic-thermalctld/scripts/thermalctld
+++ b/sonic-thermalctld/scripts/thermalctld
@@ -55,7 +55,7 @@ def log_on_status_changed(normal_status, normal_log, abnormal_log):
     if normal_status:
         logger.log_notice(normal_log)
     else:
-        logger.log_notice(abnormal_log)
+        logger.log_warning(abnormal_log)
 
 
 class FanStatus(object):

--- a/sonic-thermalctld/scripts/thermalctld
+++ b/sonic-thermalctld/scripts/thermalctld
@@ -10,26 +10,32 @@ try:
     import sys
     import time
     import signal
-    import multiprocessing
     import threading
     from datetime import datetime
     from swsscommon import swsscommon
     from sonic_daemon_base import daemon_base
     from sonic_daemon_base.daemon_base import Logger
     from sonic_daemon_base.daemon_base import DaemonBase
+    from sonic_daemon_base.task_base import ProcessTaskBase
+    from sonic_platform_common.fan_base import FanBase
 except ImportError, e:
-    raise ImportError (str(e) + " - required module not found")
-
+    raise ImportError(str(e) + " - required module not found")
 
 SYSLOG_IDENTIFIER = 'thermalctld'
-NOT_AVAILIABLE = 'N/A'
+NOT_AVAILABLE = 'N/A'
 logger = Logger(SYSLOG_IDENTIFIER)
 
 
 # utility functions
 
 # try get information from platform API and return a default value if caught NotImplementedError
-def try_get(callback, default=NOT_AVAILIABLE):
+def try_get(callback, default=NOT_AVAILABLE):
+    """
+    Handy function to invoke the callback and catch NotImplementedError
+    :param callback: Callback to be invoked
+    :param default: Default return value if exception occur
+    :return: Default return value if exception occur else return value of the callback
+    """
     try:
         ret = callback()
     except NotImplementedError:
@@ -38,71 +44,110 @@ def try_get(callback, default=NOT_AVAILIABLE):
     return default if ret is None else ret
 
 
-#
-# TaskBase =====================================================================
-#
-class ProcessTaskBase(object): # TODO: put this class to swss-platform-common
+class FanStatus(object):
     def __init__(self):
-        self.task_process = None
-        self.task_stopping_event = multiprocessing.Event()
+        """
+        Constructor of FanStatus
+        """
+        self.presence = True
+        self.under_speed = False
+        self.over_speed = False
+        self.invalid_direction = False
 
-    def task_worker(self):
-        pass
+    def set_presence(self, presence):
+        """
+        Set and cache Fan presence status
+        :param presence: Fan presence status
+        :return: True if status changed else False
+        """
+        if presence == self.presence:
+            return False
 
-    def task_run(self):
-        if self.task_stopping_event.is_set():
-            return
+        self.presence = presence
+        return True
 
-        self.task_process = multiprocessing.Process(target=self.task_worker)
-        self.task_process.start()
+    def set_under_speed(self, speed, target_speed, tolerance):
+        """
+        Set and cache Fan under speed status
+        :param speed: Fan speed
+        :param target_speed: Fan target speed
+        :param tolerance: Threshold between Fan speed and target speed
+        :return: True if status changed else False
+        """
+        if speed == NOT_AVAILABLE or target_speed == NOT_AVAILABLE or tolerance == NOT_AVAILABLE:
+            old_status = self.under_speed
+            self.under_speed = False
+            if old_status != self.under_speed:
+                logger.log_warning('Fan speed or target_speed or tolerance become unavailable.')
+            return old_status != self.under_speed
 
-    def task_stop(self):
-        self.task_stopping_event.set()
-        os.kill(self.task_process.pid, signal.SIGKILL)
+        status = (target_speed - speed > tolerance)
+        if status == self.under_speed:
+            return False
 
+        self.under_speed = status
+        return True
 
-#
-# TaskBase =====================================================================
-#
-class ThreadTaskBase(object): # TODO: put this class to swss-platform-common;
-    def __init__(self):
-        self.task_thread = None
-        self.task_stopping_event = threading.Event()
+    def set_over_speed(self, speed, target_speed, tolerance):
+        """
+        Set and cache Fan over speed status
+        :param speed: Fan speed
+        :param target_speed: Fan target speed
+        :param tolerance: Threshold between Fan speed and target speed
+        :return: True if status changed else False
+        """
+        if speed == NOT_AVAILABLE or target_speed == NOT_AVAILABLE or tolerance == NOT_AVAILABLE:
+            old_status = self.over_speed
+            self.over_speed = False
+            if old_status != self.under_speed:
+                logger.log_warning('Fan speed or target_speed or tolerance become unavailable.')
+            return old_status != self.over_speed
 
-    def task_worker(self):
-        pass
+        status = (speed - target_speed > tolerance)
+        if status == self.over_speed:
+            return False
 
-    def task_run(self):
-        if self.task_stopping_event.is_set():
-            return
+        self.over_speed = status
+        return True
 
-        self.task_thread = threading.Thread(target=self.task_worker)
-        self.task_thread.start()
-
-    def task_stop(self):
-        self.task_stopping_event.set()
-        self.task_thread.join()
+    def is_ok(self):
+        """
+        Indicate the Fan works as expect
+        :return: True if Fan works normal else False
+        """
+        return self.presence and not self.under_speed and not self.over_speed and not self.invalid_direction
 
 
 #
 # FanUpdater ===================================================================
 #
 class FanUpdater(object):
+    # Fan information table name in database
     FAN_INFO_TABLE_NAME = 'FAN_INFO'
 
-    # Fan bitmap defines (python 2 does not support Enum, we should use Enum to refactor this if we turn to python 3)
-    FAN_OK = 0
-    FAN_NOT_PRESENCE = 1
-    FAN_UNEXPECT_SPEED = 2
-    FAN_INVALID_DIRECTION = 4
-
     def __init__(self, chassis):
+        """
+        Constructor for FanUpdater
+        :param chassis: Object representing a platform chassis
+        """
         self.chassis = chassis
-        self.prensences = {}
+        self.fan_status_dict = {}
         state_db = daemon_base.db_connect(swsscommon.STATE_DB)
         self.table = swsscommon.Table(state_db, FanUpdater.FAN_INFO_TABLE_NAME)
 
+    def destroy(self):
+        """
+        Destructor of FanUpdater
+        :return:
+        """
+        for name in self.fan_status_dict.keys():
+            self.table._del(name)
+
     def update(self):
+        """
+        Update all Fan information to database
+        :return:
+        """
         logger.log_info("Start fan updating")
         for index, fan in enumerate(self.chassis.get_all_fans()):
             self._refresh_fan_status(fan, index)
@@ -112,142 +157,315 @@ class FanUpdater(object):
             for fan_index, fan in psu.get_all_fans():
                 self._refresh_fan_status(fan, fan_index, '{} FAN'.format(psu_name))
 
-        self.table.flush()
         logger.log_info("Stop fan updating")
 
     def _refresh_fan_status(self, fan, index, name_prefix='FAN'):
-        # What if there is duplicate fan name?
+        """
+        Get Fan status by platform API and write to database for a given Fan
+        :param fan: Object representing a platform Fan
+        :param index: Index of the Fan object in the platform
+        :param name_prefix: name prefix of Fan object if Fan.get_name not presented
+        :return:
+        """
         fan_name = try_get(fan.get_name, '{} {}'.format(name_prefix, index + 1))
+        if fan_name not in self.fan_status_dict:
+            self.fan_status_dict[fan_name] = FanStatus()
+
+        fan_status = self.fan_status_dict[fan_name]
+
         presence = try_get(fan.get_presence, False)
         speed = try_get(fan.get_speed)
         speed_tolerance = try_get(fan.get_speed_tolerance)
         speed_target = try_get(fan.get_target_speed)
 
-        if fan_name not in self.prensences:
-            self.prensences[fan_name] = True
+        set_led = False
+        if fan_status.set_presence(presence):
+            set_led = True
+            self._on_presense_status_changed(fan_name, fan_status)
 
-        if presence != self.prensences[fan_name]:
-            self._report_presense(fan_name, presence)
-            self.prensences[fan_name] = presence
+        if fan_status.set_under_speed(speed, speed_target, speed_tolerance):
+            set_led = True
+            self._on_under_speed_status_changed(fan_name, fan_status)
 
-        fan_bitmap = FanUpdater.FAN_OK
-        if not presence:
-            fan_bitmap |= FanUpdater.FAN_NOT_PRESENCE
-        else:
-            fan_bitmap |= self._get_fan_bitmap(speed, speed_target, speed_tolerance)
+        if fan_status.set_over_speed(speed, speed_target, speed_tolerance):
+            set_led = True
+            self._on_over_speed_status_changed(fan_name, fan_status)
 
-        self._set_fan_led(fan_bitmap)
+        # TODO: handle invalid fan direction
+
+        if set_led:
+            self._set_fan_led(fan, fan_name, fan_status)
 
         fvs = swsscommon.FieldValuePairs(
-                [('presence', str(presence)),
-                ('model', str(try_get(fan.get_model))), 
-                ('serial', str(try_get(fan.get_serial))), 
-                ('status', str(try_get(fan.get_status, False))),
-                ('direction', str(try_get(fan.get_direction))),
-                ('speed', str(speed)),
-                ('speed_tolerance', str(speed_tolerance)),
-                ('speed_target', str(speed_target)),
-                ('led_status', str(try_get(fan.get_status_led))),
-                ('timestamp', datetime.now().strftime('%Y%m%d %H:%M:%S'))
-                ])
-        
+            [('presence', str(presence)),
+             ('model', str(try_get(fan.get_model))),
+             ('serial', str(try_get(fan.get_serial))),
+             ('status', str(try_get(fan.get_status, False))),
+             ('direction', str(try_get(fan.get_direction))),
+             ('speed', str(speed)),
+             ('speed_tolerance', str(speed_tolerance)),
+             ('speed_target', str(speed_target)),
+             ('led_status', str(try_get(fan.get_status_led))),
+             ('timestamp', datetime.now().strftime('%Y%m%d %H:%M:%S'))
+             ])
+
         self.table.set(fan_name, fvs)
 
-    def _report_presense(self, fan_name, presence):
-        if presence:
-            logger.log_warning('Fan removed warning cleared: {} was inserted.'.format(fan_name))
+    def _on_presense_status_changed(self, fan_name, fan_status):
+        """
+        Called when fan presence status changed
+        :param fan_name: Name of the Fan object in case any vendor not implement Fan.get_name
+        :param fan_status: Object representing the FanStatus
+        :return:
+        """
+        if fan_status.presence:
+            logger.log_notice('Fan removed warning cleared: {} was inserted.'.format(fan_name))
         else:
-            logger.log_warning('Fan removed warning: {} was removed from the system, potential overheat hazard!'.format(fan_name))
+            logger.log_warning(
+                'Fan removed warning: {} was removed from the system, potential overheat hazard!'.format(fan_name))
 
-    def _get_fan_bitmap(self, speed, speed_target, speed_tolerance):
-        if speed != NOT_AVAILIABLE and speed_target != NOT_AVAILIABLE and speed_tolerance != NOT_AVAILIABLE:
-            return FanUpdater.FAN_UNEXPECT_SPEED if abs(speed - speed_target) > speed_tolerance else FanUpdater.FAN_OK
+    def _on_under_speed_status_changed(self, fan_name, fan_status):
+        """
+        Called when fan under speed status changed
+        :param fan_name: Name of the Fan object in case any vendor not implement Fan.get_name
+        :param fan_status: Object representing the FanStatus
+        :return:
+        """
+        if not fan_status.under_speed:
+            logger.log_warning('Fan under speed warning cleared: {} speed back to normal.'.format(fan_name))
         else:
-            return FanUpdater.FAN_OK
+            logger.log_notice('Fan under speed warning: {} speed over tolerance.'.format(fan_name))
 
-    def _set_fan_led(self, fan, fan_bitmap):
-        if fan_bitmap == FanUpdater.FAN_OK:
+    def _on_over_speed_status_changed(self, fan_name, fan_status):
+        """
+        Called when fan over speed status changed
+        :param fan_name: Name of the Fan object in case any vendor not implement Fan.get_name
+        :param fan_status: Object representing the FanStatus
+        :return:
+        """
+        if not fan_status.over_speed:
+            logger.log_warning('Fan over speed warning cleared: {} speed back to normal.'.format(fan_name))
+        else:
+            logger.log_notice('Fan over speed warning: {} speed over tolerance.'.format(fan_name))
+
+    def _set_fan_led(self, fan, fan_name, fan_status):
+        """
+        Set fan led according to current status
+        :param fan: Object representing a platform Fan
+        :param fan_name: Name of the Fan object in case any vendor not implement Fan.get_name
+        :param fan_status: Object representing the FanStatus
+        :return:
+        """
+        if fan_status.is_ok():
             fan.set_status_led(FanBase.STATUS_LED_COLOR_GREEN)
         else:
+            # TODO: wait for Kebo to define the mapping of fan status to led color,
+            # just set it to red so far
             fan.set_status_led(FanBase.STATUS_LED_COLOR_RED)
 
-        
+
+class TemperStatus(object):
+    def __init__(self):
+        self.over_temper = False
+        self.under_temper = True
+
+    def set_over_temper(self, temper, threshold):
+        """
+        Set over temperature status
+        :param temper: Temperature
+        :param threshold: High threshold
+        :return: True if over temperature status changed else False
+        """
+        if temper == NOT_AVAILABLE or threshold == NOT_AVAILABLE:
+            old_status = self.over_temper
+            self.over_temper = False
+            if old_status != self.over_temper:
+                logger.log_warning('Fan temperature or high threshold become unavailable.')
+            return self.over_temper == old_status
+
+        status = temper > threshold
+        if status == self.over_temper:
+            return False
+
+        self.over_temper = status
+        return True
+
+    def set_under_temper(self, temper, threshold):
+        """
+        Set over temperature status
+        :param temper: Temperature
+        :param threshold: Low threshold
+        :return: True if under temperature status changed else False
+        """
+        if temper == NOT_AVAILABLE or threshold == NOT_AVAILABLE:
+            old_status = self.under_temper
+            self.under_temper = False
+            if old_status != self.under_temper:
+                logger.log_warning('Fan temperature or low threshold become unavailable.')
+            return self.under_temper == old_status
+
+        status = temper < threshold
+        if status == self.under_temper:
+            return False
+
+        self.under_temper = status
+        return True
+
+
 #
 # TemperUpdater ======================================================================
 #
 class TemperUpdater(object):
+    # Temperature information table name in database
     TEMPER_INFO_TABLE_NAME = 'TEMPERATURE_INFO'
 
     def __init__(self, chassis):
+        """
+        Constructor of TemperUpdater
+        :param chassis: Object representing a platform chassis
+        """
         self.chassis = chassis
-        self.temper_warnings = [(False, False)] * chassis.get_num_thermals()
+        self.temper_status_dict = {}
         state_db = daemon_base.db_connect(swsscommon.STATE_DB)
         self.table = swsscommon.Table(state_db, TemperUpdater.TEMPER_INFO_TABLE_NAME)
 
+    def destroy(self):
+        """
+        Destructor of TemperUpdater
+        :return:
+        """
+        for name in self.temper_status_dict.keys():
+            self.table._del(name)
+
     def update(self):
+        """
+        Update all temperature information to database
+        :return:
+        """
         logger.log_info("Start temperature updating")
         for index, thermal in enumerate(self.chassis.get_all_thermals()):
             self._refresh_temper_status(thermal, index)
 
-        self.table.flush()
         logger.log_info("Stop temperature updating")
 
     def _refresh_temper_status(self, thermal, index):
+        """
+        Get temperature status by platform API and write to database
+        :param thermal: Object representing a platform thermal zone
+        :param index: Index of the thermal object in platform chassis
+        :return:
+        """
         name = try_get(thermal.get_name, 'Thermal {}'.format(index + 1))
+        if name not in self.temper_status_dict:
+            self.temper_status_dict = TemperStatus()
+
+        temper_status = self.temper_status_dict[name]
+
         temperature = try_get(thermal.get_temperature)
         high_threshold = try_get(thermal.get_high_threshold)
         low_threshold = try_get(thermal.get_low_threshold)
 
-        warning = None
-        if temperature != NOT_AVAILIABLE:
-            if high_threshold != NOT_AVAILIABLE:
-                warning = temperature > high_threshold
-                if warning != self.temper_warnings[index][0]:
-                    self._report_temperature(name, temperature, 'High', high_threshold, warning)
-                    self.temper_warnings[index][0] = warning
+        warning = False
+        if temper_status.set_over_temper(temperature, high_threshold):
+            self._on_over_temper_status_changed(name, temperature, high_threshold, temper_status)
+            warning = True
 
-            if low_threshold != NOT_AVAILIABLE:
-                warning = temperature < low_threshold
-                if warning != self.temper_warnings[index][1]:
-                    self._report_temperature(name, temperature, 'Low', low_threshold, warning)
-                    self.temper_warnings[index][1] = warning
+        if temper_status.set_under_temper(temperature, low_threshold):
+            self._on_under_temper_status_changed(name, temperature, high_threshold, temper_status)
+            warning = True
 
         fvs = swsscommon.FieldValuePairs(
-                [('temperature', str(temperature)),
-                ('high_threshold', str(high_threshold)), 
-                ('low_threshold', str(low_threshold)), 
-                ('warning_status', str(warning)),
-                ('critical_high_threshold', NOT_AVAILIABLE),
-                ('critical_low_threshold', NOT_AVAILIABLE),
-                ('timestamp', datetime.now().strftime('%Y%m%d %H:%M:%S'))
-                ])
+            [('temperature', str(temperature)),
+             ('high_threshold', str(high_threshold)),
+             ('low_threshold', str(low_threshold)),
+             ('warning_status', str(warning)),
+             ('critical_high_threshold', NOT_AVAILABLE),
+             ('critical_low_threshold', NOT_AVAILABLE),
+             ('timestamp', datetime.now().strftime('%Y%m%d %H:%M:%S'))
+             ])
 
         self.table.set(name, fvs)
 
-    def _report_temperature(self, name, temperature, category, threshold, warning):
-        if warning:
-            logger.log_warning('{} temperature warning: {} current temperature {}C, {} threshold {}C'.format(category, name, temperature, category.lower(), threshold))
+    def _on_over_temper_status_changed(self, name, temperature, high_threshold, temper_status):
+        """
+        Called when over temperature status changed
+        :param name: Name of thermal zone
+        :param temperature: Temperature of thermal zone
+        :param high_threshold: High threshold of thermal zone
+        :param temper_status: Temperature status
+        :return:
+        """
+        if temper_status.over_temper:
+            logger.log_warning(
+                'High temperature warning: {} current temperature {}C, high threshold {}C'.
+                    format(name, temperature, high_threshold))
         else:
-            logger.log_warning('{} temperature warning cleared: {} temperature restore to {}C, {} threshold {}C.'.format(category, name, temperature, category.lower(), threshold))
-        
+            logger.log_notice(
+                'High temperature warning cleared: {} temperature restore to {}C, high threshold {}C.'.
+                    format(name, temperature, high_threshold))
+
+    def _on_under_temper_status_changed(self, name, temperature, low_threshold, temper_status):
+        """
+        Called when under temperature status changed
+        :param name: Name of thermal zone
+        :param temperature: Temperature of thermal zone
+        :param low_threshold: Low threshold of thermal zone
+        :param temper_status: Temperature status
+        :return:
+        """
+        if temper_status.over_temper:
+            logger.log_warning(
+                'Low temperature warning: {} current temperature {}C, low threshold {}C'.
+                    format(name, temperature, low_threshold))
+        else:
+            logger.log_notice(
+                'Low temperature warning cleared: {} temperature restore to {}C, low threshold {}C.'.
+                    format(name, temperature, low_threshold))
+
 
 class ThermalMonitor(ProcessTaskBase):
+    # Initial update interval
+    INITIAL_INTERVAL = 5
+    # Update interval value
     UPDATE_INTERVAL = 60
+    # Update elapse threshold. If update used time is larger than the value, generate a warning log.
+    UPDATE_ELAPSE_THRESHOLD = 30
 
     def __init__(self, chassis):
+        """
+        Constructor for ThermalMonitor
+        :param chassis: Object representing a platform chassis
+        """
         ProcessTaskBase.__init__(self)
-        self.chassis = chassis
-        self.fan_monitor = FanUpdater(chassis)
-        self.temper_monitor = TemperUpdater(chassis)
+        self.fan_updater = FanUpdater(chassis)
+        self.temper_updater = TemperUpdater(chassis)
 
     def task_worker(self):
+        """
+        Thread function to handle Fan status update and temperature status update
+        :return:
+        """
         logger.log_info("Start thermal monitoring loop")
 
-        # Start loop to update temperature info in DB periodically
-        while not self.task_stopping_event.wait(ThermalMonitor.UPDATE_INTERVAL):
-            self.fan_monitor.update()
-            self.temper_monitor.update()
-        
+        # Start loop to update fan, temperature info in DB periodically
+        wait_time = ThermalMonitor.INITIAL_INTERVAL
+        while not self.task_stopping_event.wait(wait_time):
+            begin = time.time()
+            self.fan_updater.update()
+            self.temper_updater.update()
+            elapse = time.time() - begin
+            if elapse < ThermalMonitor.UPDATE_INTERVAL:
+                wait_time = ThermalMonitor.UPDATE_INTERVAL - elapse
+            else:
+                wait_time = ThermalMonitor.INITIAL_INTERVAL
+
+            if elapse > ThermalMonitor.UPDATE_ELAPSE_THRESHOLD:
+                logger.log_warning('Update fan and temperature status takes {} seconds, '
+                                   'there might be performance risk'.format(elapse))
+
+        self.fan_updater.destroy()
+        self.temper_updater.destroy()
+
         logger.log_info("Stop thermal monitoring loop")
 
 
@@ -255,12 +473,24 @@ class ThermalMonitor(ProcessTaskBase):
 # Daemon =======================================================================
 #
 class ThermalControlDaemon(DaemonBase):
+    # Interval to run thermal control logical
+    INTERVAL = 60
+
     def __init__(self):
+        """
+        Constructor of ThermalControlDaemon
+        """
         DaemonBase.__init__(self)
         self.stop_event = threading.Event()
 
     # Signal handler
     def signal_handler(self, sig, frame):
+        """
+        Signal handler
+        :param sig: Signal number
+        :param frame: not used
+        :return:
+        """
         if sig == signal.SIGHUP:
             logger.log_info("Caught SIGHUP - ignoring...")
         elif sig == signal.SIGINT:
@@ -273,6 +503,10 @@ class ThermalControlDaemon(DaemonBase):
             logger.log_warning("Caught unhandled signal '" + sig + "'")
 
     def run(self):
+        """
+        Run main logical of this daemon
+        :return:
+        """
         logger.log_info("Starting up...")
 
         import sonic_platform.platform
@@ -281,8 +515,8 @@ class ThermalControlDaemon(DaemonBase):
         thermal_monitor = ThermalMonitor(chassis)
         thermal_monitor.task_run()
 
-        while not self.stop_event.wait(60): # TODO: remove hard coded time interval value
-            pass # No main thread job for now
+        while not self.stop_event.wait(ThermalControlDaemon.INTERVAL):
+            pass  # No main thread job for now
 
         thermal_monitor.task_stop()
 

--- a/sonic-thermalctld/scripts/thermalctld
+++ b/sonic-thermalctld/scripts/thermalctld
@@ -44,6 +44,20 @@ def try_get(callback, default=NOT_AVAILABLE):
     return default if ret is None else ret
 
 
+def log_on_status_changed(normal_status, normal_log, abnormal_log):
+    """
+    Log when any status changed
+    :param normal_status: Expected status.
+    :param normal_log: Log string for expected status.
+    :param abnormal_log: Log string for unexpected status
+    :return:
+    """
+    if normal_status:
+        logger.log_notice(normal_log)
+    else:
+        logger.log_notice(abnormal_log)
+
+
 class FanStatus(object):
     def __init__(self):
         """
@@ -66,6 +80,13 @@ class FanStatus(object):
         self.presence = presence
         return True
 
+    def _check_speed_value_available(self, speed, target_speed, tolerance, current_status):
+        if speed == NOT_AVAILABLE or target_speed == NOT_AVAILABLE or tolerance == NOT_AVAILABLE:
+            if current_status is True:
+                logger.log_warning('Fan speed or target_speed or tolerance become unavailable.')
+            return False
+        return True
+
     def set_under_speed(self, speed, target_speed, tolerance):
         """
         Set and cache Fan under speed status
@@ -74,11 +95,9 @@ class FanStatus(object):
         :param tolerance: Threshold between Fan speed and target speed
         :return: True if status changed else False
         """
-        if speed == NOT_AVAILABLE or target_speed == NOT_AVAILABLE or tolerance == NOT_AVAILABLE:
+        if not self._check_speed_value_available(speed, target_speed, tolerance, self.under_speed):
             old_status = self.under_speed
             self.under_speed = False
-            if old_status != self.under_speed:
-                logger.log_warning('Fan speed or target_speed or tolerance become unavailable.')
             return old_status != self.under_speed
 
         status = (target_speed - speed > tolerance)
@@ -96,11 +115,9 @@ class FanStatus(object):
         :param tolerance: Threshold between Fan speed and target speed
         :return: True if status changed else False
         """
-        if speed == NOT_AVAILABLE or target_speed == NOT_AVAILABLE or tolerance == NOT_AVAILABLE:
+        if not self._check_speed_value_available(speed, target_speed, tolerance, self.over_speed):
             old_status = self.over_speed
             self.over_speed = False
-            if old_status != self.under_speed:
-                logger.log_warning('Fan speed or target_speed or tolerance become unavailable.')
             return old_status != self.over_speed
 
         status = (speed - target_speed > tolerance)
@@ -181,15 +198,25 @@ class FanUpdater(object):
         set_led = False
         if fan_status.set_presence(presence):
             set_led = True
-            self._on_presense_status_changed(fan_name, fan_status)
+            log_on_status_changed(fan_status.presence,
+                                  'Fan removed warning cleared: {} was inserted.'.format(fan_name),
+                                  'Fan removed warning: {} was removed from '
+                                  'the system, potential overheat hazard'.format(fan_name)
+                                  )
 
         if fan_status.set_under_speed(speed, speed_target, speed_tolerance):
             set_led = True
-            self._on_under_speed_status_changed(fan_name, fan_status)
+            log_on_status_changed(not fan_status.under_speed,
+                                  'Fan under speed warning cleared: {} speed back to normal.'.format(fan_name),
+                                  'Fan under speed warning: {} speed over tolerance.'.format(fan_name)
+                                  )
 
         if fan_status.set_over_speed(speed, speed_target, speed_tolerance):
             set_led = True
-            self._on_over_speed_status_changed(fan_name, fan_status)
+            log_on_status_changed(not fan_status.over_speed,
+                                  'Fan over speed warning cleared: {} speed back to normal.'.format(fan_name),
+                                  'Fan over speed warning: {} speed over tolerance.'.format(fan_name)
+                                  )
 
         # TODO: handle invalid fan direction
 
@@ -211,43 +238,6 @@ class FanUpdater(object):
 
         self.table.set(fan_name, fvs)
 
-    def _on_presense_status_changed(self, fan_name, fan_status):
-        """
-        Called when fan presence status changed
-        :param fan_name: Name of the Fan object in case any vendor not implement Fan.get_name
-        :param fan_status: Object representing the FanStatus
-        :return:
-        """
-        if fan_status.presence:
-            logger.log_notice('Fan removed warning cleared: {} was inserted.'.format(fan_name))
-        else:
-            logger.log_warning(
-                'Fan removed warning: {} was removed from the system, potential overheat hazard!'.format(fan_name))
-
-    def _on_under_speed_status_changed(self, fan_name, fan_status):
-        """
-        Called when fan under speed status changed
-        :param fan_name: Name of the Fan object in case any vendor not implement Fan.get_name
-        :param fan_status: Object representing the FanStatus
-        :return:
-        """
-        if not fan_status.under_speed:
-            logger.log_warning('Fan under speed warning cleared: {} speed back to normal.'.format(fan_name))
-        else:
-            logger.log_notice('Fan under speed warning: {} speed over tolerance.'.format(fan_name))
-
-    def _on_over_speed_status_changed(self, fan_name, fan_status):
-        """
-        Called when fan over speed status changed
-        :param fan_name: Name of the Fan object in case any vendor not implement Fan.get_name
-        :param fan_status: Object representing the FanStatus
-        :return:
-        """
-        if not fan_status.over_speed:
-            logger.log_warning('Fan over speed warning cleared: {} speed back to normal.'.format(fan_name))
-        else:
-            logger.log_notice('Fan over speed warning: {} speed over tolerance.'.format(fan_name))
-
     def _set_fan_led(self, fan, fan_name, fan_status):
         """
         Set fan led according to current status
@@ -267,7 +257,14 @@ class FanUpdater(object):
 class TemperStatus(object):
     def __init__(self):
         self.over_temper = False
-        self.under_temper = True
+        self.under_temper = False
+
+    def _check_temper_value_available(self, temper, threshold, current_status):
+        if temper == NOT_AVAILABLE or threshold == NOT_AVAILABLE:
+            if current_status is True:
+                logger.log_warning('Fan temperature or threshold become unavailable.')
+            return False
+        return True
 
     def set_over_temper(self, temper, threshold):
         """
@@ -276,12 +273,10 @@ class TemperStatus(object):
         :param threshold: High threshold
         :return: True if over temperature status changed else False
         """
-        if temper == NOT_AVAILABLE or threshold == NOT_AVAILABLE:
+        if self._check_temper_value_available(temper, threshold, self.over_temper):
             old_status = self.over_temper
             self.over_temper = False
-            if old_status != self.over_temper:
-                logger.log_warning('Fan temperature or high threshold become unavailable.')
-            return self.over_temper == old_status
+            return old_status != self.over_temper
 
         status = temper > threshold
         if status == self.over_temper:
@@ -297,12 +292,10 @@ class TemperStatus(object):
         :param threshold: Low threshold
         :return: True if under temperature status changed else False
         """
-        if temper == NOT_AVAILABLE or threshold == NOT_AVAILABLE:
+        if self._check_temper_value_available(temper, threshold, self.under_temper):
             old_status = self.under_temper
             self.under_temper = False
-            if old_status != self.under_temper:
-                logger.log_warning('Fan temperature or low threshold become unavailable.')
-            return self.under_temper == old_status
+            return old_status != self.under_temper
 
         status = temper < threshold
         if status == self.under_temper:
@@ -367,11 +360,21 @@ class TemperUpdater(object):
 
         warning = False
         if temper_status.set_over_temper(temperature, high_threshold):
-            self._on_over_temper_status_changed(name, temperature, high_threshold, temper_status)
+            log_on_status_changed(not temper_status.over_temper,
+                                  'High temperature warning: {} current temperature {}C, high threshold {}C'.
+                                  format(name, temperature, high_threshold),
+                                  'High temperature warning cleared: {} temperature restore to {}C, high threshold {}C.'.
+                                  format(name, temperature, high_threshold)
+                                  )
             warning = True
 
         if temper_status.set_under_temper(temperature, low_threshold):
-            self._on_under_temper_status_changed(name, temperature, high_threshold, temper_status)
+            log_on_status_changed(not temper_status.under_temper,
+                                  'Low temperature warning: {} current temperature {}C, low threshold {}C'.
+                                  format(name, temperature, low_threshold),
+                                  'Low temperature warning cleared: {} temperature restore to {}C, low threshold {}C.'.
+                                  format(name, temperature, low_threshold)
+                                  )
             warning = True
 
         fvs = swsscommon.FieldValuePairs(
@@ -385,42 +388,6 @@ class TemperUpdater(object):
              ])
 
         self.table.set(name, fvs)
-
-    def _on_over_temper_status_changed(self, name, temperature, high_threshold, temper_status):
-        """
-        Called when over temperature status changed
-        :param name: Name of thermal zone
-        :param temperature: Temperature of thermal zone
-        :param high_threshold: High threshold of thermal zone
-        :param temper_status: Temperature status
-        :return:
-        """
-        if temper_status.over_temper:
-            logger.log_warning(
-                'High temperature warning: {} current temperature {}C, high threshold {}C'.
-                    format(name, temperature, high_threshold))
-        else:
-            logger.log_notice(
-                'High temperature warning cleared: {} temperature restore to {}C, high threshold {}C.'.
-                    format(name, temperature, high_threshold))
-
-    def _on_under_temper_status_changed(self, name, temperature, low_threshold, temper_status):
-        """
-        Called when under temperature status changed
-        :param name: Name of thermal zone
-        :param temperature: Temperature of thermal zone
-        :param low_threshold: Low threshold of thermal zone
-        :param temper_status: Temperature status
-        :return:
-        """
-        if temper_status.over_temper:
-            logger.log_warning(
-                'Low temperature warning: {} current temperature {}C, low threshold {}C'.
-                    format(name, temperature, low_threshold))
-        else:
-            logger.log_notice(
-                'Low temperature warning cleared: {} temperature restore to {}C, low threshold {}C.'.
-                    format(name, temperature, low_threshold))
 
 
 class ThermalMonitor(ProcessTaskBase):

--- a/sonic-thermalctld/scripts/thermalctld
+++ b/sonic-thermalctld/scripts/thermalctld
@@ -108,8 +108,9 @@ class FanUpdater(object):
             self._refresh_fan_status(fan, index)
 
         for psu_index, psu in enumerate(self.chassis.get_all_psus()):
+            psu_name = try_get(psu.get_name, 'PSU {}'.format(psu_index))
             for fan_index, fan in psu.get_all_fans():
-                self._refresh_fan_status(fan, fan_index, 'PSU {} FAN'.format(psu_index))
+                self._refresh_fan_status(fan, fan_index, '{} FAN'.format(psu_name))
 
         self.table.flush()
         logger.log_info("Stop fan updating")
@@ -134,7 +135,6 @@ class FanUpdater(object):
             fan_bitmap |= FanUpdater.FAN_NOT_PRESENCE
         else:
             fan_bitmap |= self._get_fan_bitmap(speed, speed_target, speed_tolerance)
-
 
         fvs = swsscommon.FieldValuePairs(
                 [('presence', str(presence)),

--- a/sonic-thermalctld/scripts/thermalctld
+++ b/sonic-thermalctld/scripts/thermalctld
@@ -1,0 +1,293 @@
+#!/usr/bin/env python2
+
+"""
+    thermalctld
+    Thermal control daemon for SONiC
+"""
+
+try:
+    import os
+    import sys
+    import time
+    import signal
+    import multiprocessing
+    import threading
+    from datetime import datetime
+    from swsscommon import swsscommon
+    from sonic_daemon_base import daemon_base
+    from sonic_daemon_base.daemon_base import Logger
+    from sonic_daemon_base.daemon_base import DaemonBase
+except ImportError, e:
+    raise ImportError (str(e) + " - required module not found")
+
+
+SYSLOG_IDENTIFIER = 'thermalctld'
+NOT_AVAILIABLE = 'N/A'
+logger = Logger(SYSLOG_IDENTIFIER)
+
+
+# utility functions
+
+# try get information from platform API and return a default value if caught NotImplementedError
+def try_get(callback, default=NOT_AVAILIABLE):
+    try:
+        ret = callback()
+    except NotImplementedError:
+        ret = None
+
+    return default if ret is None else ret
+
+
+#
+# TaskBase =====================================================================
+#
+class ProcessTaskBase(object): # TODO: put this class to swss-platform-common
+    def __init__(self):
+        self.task_process = None
+        self.task_stopping_event = multiprocessing.Event()
+
+    def task_worker(self):
+        pass
+
+    def task_run(self):
+        if self.task_stopping_event.is_set():
+            return
+
+        self.task_process = multiprocessing.Process(target=self.task_worker)
+        self.task_process.start()
+
+    def task_stop(self):
+        self.task_stopping_event.set()
+        os.kill(self.task_process.pid, signal.SIGKILL)
+
+
+#
+# TaskBase =====================================================================
+#
+class ThreadTaskBase(object): # TODO: put this class to swss-platform-common;
+    def __init__(self):
+        self.task_thread = None
+        self.task_stopping_event = threading.Event()
+
+    def task_worker(self):
+        pass
+
+    def task_run(self):
+        if self.task_stopping_event.is_set():
+            return
+
+        self.task_thread = threading.Thread(target=self.task_worker)
+        self.task_thread.start()
+
+    def task_stop(self):
+        self.task_stopping_event.set()
+        self.task_thread.join()
+
+
+#
+# FanUpdater ===================================================================
+#
+class FanUpdater(object):
+    FAN_INFO_TABLE_NAME = 'FAN_INFO'
+
+    # Fan bitmap defines (python 2 does not support Enum, we should use Enum to refactor this if we turn to python 3)
+    FAN_OK = 0
+    FAN_NOT_PRESENCE = 1
+    FAN_UNEXPECT_SPEED = 2
+    FAN_INVALID_DIRECTION = 4
+
+    def __init__(self, chassis):
+        self.chassis = chassis
+        self.prensences = {}
+        state_db = daemon_base.db_connect(swsscommon.STATE_DB)
+        self.table = swsscommon.Table(state_db, FanUpdater.FAN_INFO_TABLE_NAME)
+
+    def update(self):
+        logger.log_info("Start fan updating")
+        for index, fan in enumerate(self.chassis.get_all_fans()):
+            self._refresh_fan_status(fan, index)
+
+        for psu_index, psu in enumerate(self.chassis.get_all_psus()):
+            for fan_index, fan in psu.get_all_fans():
+                self._refresh_fan_status(fan, fan_index, 'PSU {} FAN'.format(psu_index))
+
+        self.table.flush()
+        logger.log_info("Stop fan updating")
+
+    def _refresh_fan_status(self, fan, index, name_prefix='FAN'):
+        # What if there is duplicate fan name?
+        fan_name = try_get(fan.get_name, '{} {}'.format(name_prefix, index + 1))
+        presence = try_get(fan.get_presence, False)
+        speed = try_get(fan.get_speed)
+        speed_tolerance = try_get(fan.get_speed_tolerance)
+        speed_target = try_get(fan.get_target_speed)
+
+        if fan_name not in self.prensences:
+            self.prensences[fan_name] = True
+
+        if presence != self.prensences[fan_name]:
+            self._report_presense(fan_name, presence)
+            self.prensences[fan_name] = presence
+
+        fan_bitmap = FanUpdater.FAN_OK
+        if not presence:
+            fan_bitmap |= FanUpdater.FAN_NOT_PRESENCE
+        else:
+            fan_bitmap |= self._get_fan_bitmap(speed, speed_target, speed_tolerance)
+
+
+        fvs = swsscommon.FieldValuePairs(
+                [('presence', str(presence)),
+                ('model', str(try_get(fan.get_model))), 
+                ('serial', str(try_get(fan.get_serial))), 
+                ('status', str(try_get(fan.get_status, False))),
+                ('direction', str(try_get(fan.get_direction))),
+                ('speed', str(speed)),
+                ('speed_tolerance', str(speed_tolerance)),
+                ('speed_target', str(speed_target)),
+                ('led_status', str(try_get(fan.get_status_led))),
+                ('timestamp', datetime.now().strftime('%Y%m%d %H:%M:%S'))
+                ])
+        
+        self.table.set(fan_name, fvs)
+
+    def _report_presense(self, fan_name, presence):
+        if presence:
+            logger.log_warning('Fan removed warning cleared: {} was inserted.'.format(fan_name))
+        else:
+            logger.log_warning('Fan removed warning: {} was removed from the system, potential overheat hazard!'.format(fan_name))
+
+    def _get_fan_bitmap(self, speed, speed_target, speed_tolerance):
+        if speed != NOT_AVAILIABLE and speed_target != NOT_AVAILIABLE and speed_tolerance != NOT_AVAILIABLE:
+            return FanUpdater.FAN_UNEXPECT_SPEED if abs(speed - speed_target) > speed_tolerance else FanUpdater.FAN_OK
+        else:
+            return FanUpdater.FAN_OK
+
+        
+#
+# TemperUpdater ======================================================================
+#
+class TemperUpdater(object):
+    TEMPER_INFO_TABLE_NAME = 'TEMPERATURE_INFO'
+
+    def __init__(self, chassis):
+        self.chassis = chassis
+        self.temper_warnings = [(False, False)] * chassis.get_num_thermals()
+        state_db = daemon_base.db_connect(swsscommon.STATE_DB)
+        self.table = swsscommon.Table(state_db, TemperUpdater.TEMPER_INFO_TABLE_NAME)
+
+    def update(self):
+        logger.log_info("Start temperature updating")
+        for index, thermal in enumerate(self.chassis.get_all_thermals()):
+            self._refresh_temper_status(thermal, index)
+
+        self.table.flush()
+        logger.log_info("Stop temperature updating")
+
+    def _refresh_temper_status(self, thermal, index):
+        name = try_get(thermal.get_name, 'Thermal {}'.format(index + 1))
+        temperature = try_get(thermal.get_temperature)
+        high_threshold = try_get(thermal.get_high_threshold)
+        low_threshold = try_get(thermal.get_low_threshold)
+
+        warning = None
+        if temperature != NOT_AVAILIABLE:
+            if high_threshold != NOT_AVAILIABLE:
+                warning = temperature > high_threshold
+                if warning != self.temper_warnings[index][0]:
+                    self._report_temperature(name, temperature, 'High', high_threshold, warning)
+                    self.temper_warnings[index][0] = warning
+
+            if low_threshold != NOT_AVAILIABLE:
+                warning = temperature < low_threshold
+                if warning != self.temper_warnings[index][1]:
+                    self._report_temperature(name, temperature, 'Low', low_threshold, warning)
+                    self.temper_warnings[index][1] = warning
+
+        fvs = swsscommon.FieldValuePairs(
+                [('temperature', str(temperature)),
+                ('high_threshold', str(high_threshold)), 
+                ('low_threshold', str(low_threshold)), 
+                ('warning_status', str(warning)),
+                ('critical_high_threshold', NOT_AVAILIABLE),
+                ('critical_low_threshold', NOT_AVAILIABLE),
+                ('timestamp', datetime.now().strftime('%Y%m%d %H:%M:%S'))
+                ])
+
+        self.table.set(name, fvs)
+
+    def _report_temperature(self, name, temperature, category, threshold, warning):
+        if warning:
+            logger.log_warning('{} temperature warning: {} current temperature {}C, {} threshold {}C'.format(category, name, temperature, category.lower(), threshold))
+        else:
+            logger.log_warning('{} temperature warning cleared: {} temperature restore to {}C, {} threshold {}C.'.format(category, name, temperature, category.lower(), threshold))
+        
+
+class ThermalMonitor(ProcessTaskBase):
+    UPDATE_INTERVAL = 60
+
+    def __init__(self, chassis):
+        ProcessTaskBase.__init__(self)
+        self.chassis = chassis
+        self.fan_monitor = FanUpdater(chassis)
+        self.temper_monitor = TemperUpdater(chassis)
+
+    def task_worker(self):
+        logger.log_info("Start thermal monitoring loop")
+
+        # Start loop to update temperature info in DB periodically
+        while not self.task_stopping_event.wait(ThermalMonitor.UPDATE_INTERVAL):
+            self.fan_monitor.update()
+            self.temper_monitor.update()
+        
+        logger.log_info("Stop thermal monitoring loop")
+
+
+#
+# Daemon =======================================================================
+#
+class ThermalControlDaemon(DaemonBase):
+    def __init__(self):
+        DaemonBase.__init__(self)
+        self.stop_event = threading.Event()
+
+    # Signal handler
+    def signal_handler(self, sig, frame):
+        if sig == signal.SIGHUP:
+            logger.log_info("Caught SIGHUP - ignoring...")
+        elif sig == signal.SIGINT:
+            logger.log_info("Caught SIGINT - exiting...")
+            self.stop_event.set()
+        elif sig == signal.SIGTERM:
+            logger.log_info("Caught SIGTERM - exiting...")
+            self.stop_event.set()
+        else:
+            logger.log_warning("Caught unhandled signal '" + sig + "'")
+
+    def run(self):
+        logger.log_info("Starting up...")
+
+        import sonic_platform.platform
+        chassis = sonic_platform.platform.Platform().get_chassis()
+
+        thermal_monitor = ThermalMonitor(chassis)
+        thermal_monitor.task_run()
+
+        while not self.stop_event.wait(60): # TODO: remove hard coded time interval value
+            pass # No main thread job for now
+
+        thermal_monitor.task_stop()
+
+        logger.log_info("Shutdown...")
+
+
+#
+# Main =========================================================================
+#
+def main():
+    thermal_control = ThermalControlDaemon()
+    thermal_control.run()
+
+
+if __name__ == '__main__':
+    main()

--- a/sonic-thermalctld/scripts/thermalctld
+++ b/sonic-thermalctld/scripts/thermalctld
@@ -136,6 +136,8 @@ class FanUpdater(object):
         else:
             fan_bitmap |= self._get_fan_bitmap(speed, speed_target, speed_tolerance)
 
+        self._set_fan_led(fan_bitmap)
+
         fvs = swsscommon.FieldValuePairs(
                 [('presence', str(presence)),
                 ('model', str(try_get(fan.get_model))), 
@@ -162,6 +164,12 @@ class FanUpdater(object):
             return FanUpdater.FAN_UNEXPECT_SPEED if abs(speed - speed_target) > speed_tolerance else FanUpdater.FAN_OK
         else:
             return FanUpdater.FAN_OK
+
+    def _set_fan_led(self, fan, fan_bitmap):
+        if fan_bitmap == FanUpdater.FAN_OK:
+            fan.set_status_led(FanBase.STATUS_LED_COLOR_GREEN)
+        else:
+            fan.set_status_led(FanBase.STATUS_LED_COLOR_RED)
 
         
 #

--- a/sonic-thermalctld/scripts/thermalctld
+++ b/sonic-thermalctld/scripts/thermalctld
@@ -17,7 +17,6 @@ try:
     from sonic_daemon_base.daemon_base import Logger
     from sonic_daemon_base.daemon_base import DaemonBase
     from sonic_daemon_base.task_base import ProcessTaskBase
-    from sonic_platform_common.fan_base import FanBase
 except ImportError, e:
     raise ImportError(str(e) + " - required module not found")
 
@@ -171,10 +170,10 @@ class FanUpdater(object):
 
         for psu_index, psu in enumerate(self.chassis.get_all_psus()):
             psu_name = try_get(psu.get_name, 'PSU {}'.format(psu_index))
-            for fan_index, fan in psu.get_all_fans():
+            for fan_index, fan in enumerate(psu.get_all_fans()):
                 self._refresh_fan_status(fan, fan_index, '{} FAN'.format(psu_name))
 
-        logger.log_info("Stop fan updating")
+        logger.log_info("End fan updating")
 
     def _refresh_fan_status(self, fan, index, name_prefix='FAN'):
         """
@@ -208,14 +207,16 @@ class FanUpdater(object):
             set_led = True
             log_on_status_changed(not fan_status.under_speed,
                                   'Fan under speed warning cleared: {} speed back to normal.'.format(fan_name),
-                                  'Fan under speed warning: {} speed over tolerance.'.format(fan_name)
+                                  'Fan under speed warning: {} current speed {} - target speed {} >  tolerance {}.'.
+                                  format(fan_name, speed, speed_target, speed_tolerance)
                                   )
 
         if fan_status.set_over_speed(speed, speed_target, speed_tolerance):
             set_led = True
             log_on_status_changed(not fan_status.over_speed,
                                   'Fan over speed warning cleared: {} speed back to normal.'.format(fan_name),
-                                  'Fan over speed warning: {} speed over tolerance.'.format(fan_name)
+                                  'Fan over speed warning: {} target speed {} - current speed {} > tolerance {}.'.
+                                  format(fan_name, speed_target, speed, speed_tolerance)
                                   )
 
         # TODO: handle invalid fan direction
@@ -246,12 +247,15 @@ class FanUpdater(object):
         :param fan_status: Object representing the FanStatus
         :return:
         """
-        if fan_status.is_ok():
-            fan.set_status_led(FanBase.STATUS_LED_COLOR_GREEN)
-        else:
-            # TODO: wait for Kebo to define the mapping of fan status to led color,
-            # just set it to red so far
-            fan.set_status_led(FanBase.STATUS_LED_COLOR_RED)
+        try:
+            if fan_status.is_ok():
+                fan.set_status_led(fan.STATUS_LED_COLOR_GREEN)
+            else:
+                # TODO: wait for Kebo to define the mapping of fan status to led color,
+                # just set it to red so far
+                fan.set_status_led(fan.STATUS_LED_COLOR_RED)
+        except NotImplementedError as e:
+            logger.log_warning('Failed to set led to fan, set_status_led not implemented')
 
 
 class TemperStatus(object):
@@ -273,7 +277,7 @@ class TemperStatus(object):
         :param threshold: High threshold
         :return: True if over temperature status changed else False
         """
-        if self._check_temper_value_available(temper, threshold, self.over_temper):
+        if not self._check_temper_value_available(temper, threshold, self.over_temper):
             old_status = self.over_temper
             self.over_temper = False
             return old_status != self.over_temper
@@ -292,7 +296,7 @@ class TemperStatus(object):
         :param threshold: Low threshold
         :return: True if under temperature status changed else False
         """
-        if self._check_temper_value_available(temper, threshold, self.under_temper):
+        if not self._check_temper_value_available(temper, threshold, self.under_temper):
             old_status = self.under_temper
             self.under_temper = False
             return old_status != self.under_temper
@@ -339,7 +343,7 @@ class TemperUpdater(object):
         for index, thermal in enumerate(self.chassis.get_all_thermals()):
             self._refresh_temper_status(thermal, index)
 
-        logger.log_info("Stop temperature updating")
+        logger.log_info("End temperature updating")
 
     def _refresh_temper_status(self, thermal, index):
         """
@@ -350,7 +354,7 @@ class TemperUpdater(object):
         """
         name = try_get(thermal.get_name, 'Thermal {}'.format(index + 1))
         if name not in self.temper_status_dict:
-            self.temper_status_dict = TemperStatus()
+            self.temper_status_dict[name] = TemperStatus()
 
         temper_status = self.temper_status_dict[name]
 

--- a/sonic-thermalctld/setup.py
+++ b/sonic-thermalctld/setup.py
@@ -1,0 +1,29 @@
+from setuptools import setup
+
+setup(
+    name='sonic-thermalctld',
+    version='1.0',
+    description='Thermal control daemon for SONiC',
+    license='Apache 2.0',
+    author='SONiC Team',
+    author_email='linuxnetdev@microsoft.com',
+    url='https://github.com/Azure/sonic-platform-daemons',
+    maintainer='Junchao Chen',
+    maintainer_email='junchao@mellanox.com',
+    scripts=[
+        'scripts/thermalctld',
+    ],
+    classifiers=[
+        'Development Status :: 4 - Beta',
+        'Environment :: No Input/Output (Daemon)',
+        'Intended Audience :: Developers',
+        'Intended Audience :: Information Technology',
+        'Intended Audience :: System Administrators',
+        'License :: OSI Approved :: Apache Software License',
+        'Natural Language :: English',
+        'Operating System :: POSIX :: Linux',
+        'Programming Language :: Python :: 2.7',
+        'Topic :: System :: Hardware',
+    ],
+    keywords='sonic SONiC THERMALCONTROL thermalcontrol THERMALCTL thermalctl thermalctld'
+)


### PR DESCRIPTION
1. Add a new damon ThermalControlDaemon
2. Start a sub-process ThermalMonitor in ThermalControlDaemon
3. In sub-process ThermalMonitor, update fan status and temperature status every 60 seconds
4. In FanUpdater, read fan status by platform API and store them to database, it raises error log if need
5. In TemperUpdater, read thermal status by platform API and store them to database, it raises error log if need