### PR TITLE
[thermalctld] Run thermal policy before wait 60 seconds

### DIFF
--- a/sonic-thermalctld/scripts/thermalctld
+++ b/sonic-thermalctld/scripts/thermalctld
@@ -643,12 +643,15 @@ class ThermalControlDaemon(DaemonBase):
         except Exception as e:
             logger.log_error('Caught exception while initializing thermal manager - {}'.format(e))
 
-        while not self.stop_event.wait(ThermalControlDaemon.INTERVAL):
+        while 1:
             try:
                 if thermal_manager:
                     thermal_manager.run_policy(chassis)
             except Exception as e:
                 logger.log_error('Caught exception while running thermal policy - {}'.format(e))
+
+            if self.stop_event.wait(ThermalControlDaemon.INTERVAL):
+                break
 
         try:
             if thermal_manager:


### PR DESCRIPTION
Why I did this?

When thermalctld up, we need wait 60 seconds before we can perform thermal policies. But for some system, the temperature changed quick and we should perform thermal policies earlier.

What I did?

Change the thermal loop to perferm policy first and then wait 60 seconds.

How I verify?

Manual test