### PR TITLE
[led-mgmt] Always get fan/PSU led status from platform API to avoid status inconsistance

### DIFF
--- a/sonic-psud/scripts/psud
+++ b/sonic-psud/scripts/psud
@@ -122,8 +122,6 @@ def log_on_status_changed(normal_status, normal_log, abnormal_log):
 #
 
 class PsuStatus(object):
-    update_led_color = True
-
     def __init__(self, psu):
         self.psu = psu
         self.presence = True
@@ -325,7 +323,6 @@ class DaemonPsud(DaemonBase):
             )
         
         if set_led:
-            PsuStatus.update_led_color = True
             self._set_psu_led(psu, psu_status)
 
     def _set_psu_led(self, psu, psu_status):
@@ -339,19 +336,17 @@ class DaemonPsud(DaemonBase):
         if not platform_chassis:
             return
 
-        if PsuStatus.update_led_color:
-            for index, psu_status in self.psu_status_dict.items():
-                try:
-                    fvs = swsscommon.FieldValuePairs([
-                        ('led_status', str(try_get(psu_status.psu.get_status_led)))
-                    ])
-                except Exception as e:
-                    logger.log_warning('Failed to get led status for psu {}'.format(index))
-                    fvs = swsscommon.FieldValuePairs([
-                        ('led_status', NOT_AVAILABLE)
-                    ])
-                psu_tbl.set(PSU_INFO_KEY_TEMPLATE.format(index), fvs)
-            PsuStatus.update_led_color = False
+        for index, psu_status in self.psu_status_dict.items():
+            try:
+                fvs = swsscommon.FieldValuePairs([
+                    ('led_status', str(try_get(psu_status.psu.get_status_led)))
+                ])
+            except Exception as e:
+                logger.log_warning('Failed to get led status for psu {}'.format(index))
+                fvs = swsscommon.FieldValuePairs([
+                    ('led_status', NOT_AVAILABLE)
+                ])
+            psu_tbl.set(PSU_INFO_KEY_TEMPLATE.format(index), fvs)
 #
 # Main =========================================================================
 #

--- a/sonic-thermalctld/scripts/thermalctld
+++ b/sonic-thermalctld/scripts/thermalctld
@@ -310,8 +310,9 @@ class FanUpdater(object):
         # TODO: handle invalid fan direction
 
         # We don't set PSU led here, PSU led will be handled in psud
-        if set_led and not is_psu_fan:
-            self._set_fan_led(fan_drawer, fan, fan_name, fan_status)
+        if set_led:
+            if not is_psu_fan:
+                self._set_fan_led(fan_drawer, fan, fan_name, fan_status)
             FanStatus.update_led_color = True
 
         fvs = swsscommon.FieldValuePairs(

--- a/sonic-thermalctld/scripts/thermalctld
+++ b/sonic-thermalctld/scripts/thermalctld
@@ -66,7 +66,6 @@ def log_on_status_changed(normal_status, normal_log, abnormal_log):
 class FanStatus(object):
     absence_fan_count = 0
     fault_fan_count = 0
-    update_led_color = True
 
     def __init__(self, fan=None, is_psu_fan=False):
         """
@@ -313,7 +312,6 @@ class FanUpdater(object):
         if set_led:
             if not is_psu_fan:
                 self._set_fan_led(fan_drawer, fan, fan_name, fan_status)
-            FanStatus.update_led_color = True
 
         fvs = swsscommon.FieldValuePairs(
             [('presence', str(presence)),
@@ -352,19 +350,17 @@ class FanUpdater(object):
             logger.log_warning('Failed to set led to fan, set_status_led not implemented')
 
     def _update_led_color(self):
-        if FanStatus.update_led_color:
-            for fan_name, fan_status in self.fan_status_dict.items():
-                try:
-                    fvs = swsscommon.FieldValuePairs([
-                        ('led_status', str(try_get(fan_status.fan.get_status_led)))
-                    ])
-                except Exception as e:
-                    logger.log_warning('Failed to get led status for fan')
-                    fvs = swsscommon.FieldValuePairs([
-                        ('led_status', NOT_AVAILABLE)
-                    ])
-                self.table.set(fan_name, fvs)
-            FanStatus.update_led_color = False
+        for fan_name, fan_status in self.fan_status_dict.items():
+            try:
+                fvs = swsscommon.FieldValuePairs([
+                    ('led_status', str(try_get(fan_status.fan.get_status_led)))
+                ])
+            except Exception as e:
+                logger.log_warning('Failed to get led status for fan')
+                fvs = swsscommon.FieldValuePairs([
+                    ('led_status', NOT_AVAILABLE)
+                ])
+            self.table.set(fan_name, fvs)
 
 
 class TemperatureStatus(object):


### PR DESCRIPTION
Why I did this?

1. psud will change PSU led and thermalctld cannot detect the led status change, so it would be better to always get PSU led from platform API
2. there might be delay between set led color and it take effect

How I did this?
Always get led status from platfom API.

How I verify this?
Manual test.