### PR TITLE
[psud] Store PSU temperature and voltage information to database

### DIFF
--- a/sonic-psud/scripts/psud
+++ b/sonic-psud/scripts/psud
@@ -38,6 +38,11 @@ PSU_INFO_TABLE = 'PSU_INFO'
 PSU_INFO_KEY_TEMPLATE = 'PSU {}'
 PSU_INFO_PRESENCE_FIELD = 'presence'
 PSU_INFO_STATUS_FIELD = 'status'
+PSU_INFO_TEMP_FIELD = 'temp'
+PSU_INFO_TEMP_TH_FIELD = 'temp_th'
+PSU_INFO_VOLTAGE_FIELD = 'voltage'
+PSU_INFO_VOLTAGE_MAX_TH_FIELD = 'voltage_max_th'
+PSU_INFO_VOLTAGE_MIN_TH_FIELD = 'voltage_min_th'
 
 PSU_INFO_UPDATE_PERIOD_SECS = 3
 
@@ -249,7 +254,7 @@ class DaemonPsud(DaemonBase):
 
         while not self.stop.wait(PSU_INFO_UPDATE_PERIOD_SECS):
             psu_db_update(psu_tbl, psu_num)
-            self.update_psu_data()
+            self.update_psu_data(psu_tbl)
             self._update_led_color(psu_tbl)
 
         logger.log_info("Stop daemon main loop")
@@ -262,17 +267,17 @@ class DaemonPsud(DaemonBase):
 
         logger.log_info("Shutting down...")
 
-    def update_psu_data(self):
+    def update_psu_data(self, psu_tbl):
         if not platform_chassis:
             return
 
         for index, psu in enumerate(platform_chassis.get_all_psus()):
             try:
-                self._update_single_psu_data(index + 1, psu)
+                self._update_single_psu_data(index + 1, psu, psu_tbl)
             except Exception as e:
                 logger.log_warning("Failed to update PSU data - {}".format(e))
     
-    def _update_single_psu_data(self, index, psu):
+    def _update_single_psu_data(self, index, psu, psu_tbl):
         name = try_get(psu.get_name)
         if not name:
             name = PSU_INFO_KEY_TEMPLATE.format(index)
@@ -327,6 +332,16 @@ class DaemonPsud(DaemonBase):
         if set_led:
             PsuStatus.update_led_color = True
             self._set_psu_led(psu, psu_status)
+
+        fvs = swsscommon.FieldValuePairs(
+            [(PSU_INFO_TEMP_FIELD, temperature),
+             (PSU_INFO_TEMP_TH_FIELD, temperature_threshold),
+             (PSU_INFO_VOLTAGE_FIELD, voltage),
+             (PSU_INFO_VOLTAGE_MIN_TH_FIELD, voltage_low_threshold),
+             (PSU_INFO_VOLTAGE_MAX_TH_FIELD, voltage_high_threshold),
+            ])
+        psu_tbl.set(PSU_INFO_KEY_TEMPLATE.format(index), fvs)
+        
 
     def _set_psu_led(self, psu, psu_status):
         try:

--- a/sonic-psud/scripts/psud
+++ b/sonic-psud/scripts/psud
@@ -334,11 +334,11 @@ class DaemonPsud(DaemonBase):
             self._set_psu_led(psu, psu_status)
 
         fvs = swsscommon.FieldValuePairs(
-            [(PSU_INFO_TEMP_FIELD, temperature),
-             (PSU_INFO_TEMP_TH_FIELD, temperature_threshold),
-             (PSU_INFO_VOLTAGE_FIELD, voltage),
-             (PSU_INFO_VOLTAGE_MIN_TH_FIELD, voltage_low_threshold),
-             (PSU_INFO_VOLTAGE_MAX_TH_FIELD, voltage_high_threshold),
+            [(PSU_INFO_TEMP_FIELD, str(temperature)),
+             (PSU_INFO_TEMP_TH_FIELD, str(temperature_threshold)),
+             (PSU_INFO_VOLTAGE_FIELD, str(voltage)),
+             (PSU_INFO_VOLTAGE_MIN_TH_FIELD, str(voltage_low_threshold)),
+             (PSU_INFO_VOLTAGE_MAX_TH_FIELD, str(voltage_high_threshold)),
             ])
         psu_tbl.set(PSU_INFO_KEY_TEMPLATE.format(index), fvs)
         


### PR DESCRIPTION
Why I did this?
 
System health feature requires PSU temperature and voltage information, need store them to database for host side use.

How I did?

Get temperature and voltage information from platform API and store them to database

How I verify?

Manual test and check redis database.