### PR TITLE
[thermalctld] Optimize the thermal policy loop to make it execute every 60 seconds

### DIFF
--- a/sonic-thermalctld/scripts/thermalctld
+++ b/sonic-thermalctld/scripts/thermalctld
@@ -587,6 +587,9 @@ class ThermalMonitor(ProcessTaskBase):
 class ThermalControlDaemon(DaemonBase):
     # Interval to run thermal control logic
     INTERVAL = 60
+    RUN_POLICY_ELAPSE_THRESHOLD = 30
+    FAST_START_INTERVAL = 15
+
     POLICY_FILE = '/usr/share/sonic/platform/thermal_policy.json'
 
     def __init__(self):
@@ -638,12 +641,23 @@ class ThermalControlDaemon(DaemonBase):
         except Exception as e:
             logger.log_error('Caught exception while initializing thermal manager - {}'.format(e))
 
-        while not self.stop_event.wait(ThermalControlDaemon.INTERVAL):
+        wait_time = ThermalControlDaemon.INTERVAL
+        while not self.stop_event.wait(wait_time):
+            begin = time.time()
             try:
                 if thermal_manager:
                     thermal_manager.run_policy(chassis)
             except Exception as e:
                 logger.log_error('Caught exception while running thermal policy - {}'.format(e))
+            elapse = time.time() - begin
+            if elapse < ThermalControlDaemon.INTERVAL:
+                wait_time = ThermalControlDaemon.INTERVAL - elapse
+            else:
+                wait_time = ThermalControlDaemon.FAST_START_INTERVAL
+
+            if elapse > ThermalControlDaemon.RUN_POLICY_ELAPSE_THRESHOLD:
+                logger.log_warning('Run thermal policy takes {} seconds, '
+                                   'there might be performance risk'.format(elapse))
 
         try:
             if thermal_manager:


### PR DESCRIPTION
Why I did this?
In regression, we found that thermal policy loop takes 8~15 seconds sometimes which would enhance  the loop interval to 68~75 seconds. This change is to make the loop interval more accurate.

How I did this?
Record the elapse time for thermal policy, and start next iteration in (60 - elapse) seconds.

How I test this?
Manual test on Mellanox 2410.
