### PR TITLE
[thermalctld] Fix fan status issue in 201911

### DIFF
--- a/sonic-thermalctld/scripts/thermalctld
+++ b/sonic-thermalctld/scripts/thermalctld
@@ -251,7 +251,7 @@ class FanUpdater(logger.Logger):
             self._set_fan_led(fan, fan_name, fan_status)
 
         if fan_fault_status != NOT_AVAILABLE:
-            fan_fault_status = fan_status.is_ok()
+            fan_fault_status = fan_fault_status and fan_status.is_ok()
 
         fvs = swsscommon.FieldValuePairs(
             [('presence', str(presence)),


### PR DESCRIPTION
Why I did this?

Previous PR https://github.com/Azure/sonic-platform-daemons/pull/92 has been merged to 201911. The previous fix used a method FanStatus.is_ok, however, the implementation of this method is different between master and 201911. So we need an extra enhance for this issue.

How I did this?

fan status should be true only if FanStatus.is_ok() and fan_status is true.

How I verify this?

By manual test and regression test.