### PR TITLE
[thermalctld] Print exception using repr(e) to get more information for 201911

### DIFF
--- a/sonic-thermalctld/scripts/thermalctld
+++ b/sonic-thermalctld/scripts/thermalctld
@@ -14,7 +14,7 @@ try:
     from sonic_py_common import daemon_base, logger
     from sonic_py_common.task_base import ProcessTaskBase
 except ImportError as e:
-    raise ImportError(str(e) + " - required module not found")
+    raise ImportError(repr(e) + " - required module not found")
 
 try:
     from swsscommon import swsscommon
@@ -181,7 +181,7 @@ class FanUpdater(logger.Logger):
             try:
                 self._refresh_fan_status(fan, index)
             except Exception as e:
-                self.log_warning('Failed to update FAN status - {}'.format(e))
+                self.log_warning('Failed to update FAN status - {}'.format(repr(e)))
 
         for psu_index, psu in enumerate(self.chassis.get_all_psus()):
             psu_name = try_get(psu.get_name, 'PSU {}'.format(psu_index))
@@ -189,7 +189,7 @@ class FanUpdater(logger.Logger):
                 try:
                     self._refresh_fan_status(fan, fan_index, '{} FAN'.format(psu_name))
                 except Exception as e:
-                    self.log_warning('Failed to update PSU FAN status - {}'.format(e))
+                    self.log_warning('Failed to update PSU FAN status - {}'.format(repr(e)))
 
         self.log_debug("End fan updating")
 
@@ -417,7 +417,7 @@ class TemperatureUpdater(logger.Logger):
             try:
                 self._refresh_temperature_status(thermal, index)
             except Exception as e:
-                self.log_warning('Failed to update thermal status - {}'.format(e))
+                self.log_warning('Failed to update thermal status - {}'.format(repr(e)))
 
         self.log_debug("End temperature updating")
 
@@ -587,8 +587,10 @@ class ThermalControlDaemon(daemon_base.DaemonBase):
                 thermal_manager.initialize()
                 thermal_manager.load(ThermalControlDaemon.POLICY_FILE)
                 thermal_manager.init_thermal_algorithm(chassis)
+        except NotImplementedError:
+            self.log_warning('Thermal manager is not supported on this platform.')
         except Exception as e:
-            self.log_error('Caught exception while initializing thermal manager - {}'.format(e))
+            self.log_error('Caught exception while initializing thermal manager - {}'.format(repr(e)))
 
         wait_time = ThermalControlDaemon.INTERVAL
         while not self.stop_event.wait(wait_time):
@@ -597,7 +599,7 @@ class ThermalControlDaemon(daemon_base.DaemonBase):
                 if thermal_manager:
                     thermal_manager.run_policy(chassis)
             except Exception as e:
-                self.log_error('Caught exception while running thermal policy - {}'.format(e))
+                self.log_error('Caught exception while running thermal policy - {}'.format(repr(e)))
             elapsed = time.time() - begin
             if elapsed < ThermalControlDaemon.INTERVAL:
                 wait_time = ThermalControlDaemon.INTERVAL - elapsed
@@ -612,7 +614,7 @@ class ThermalControlDaemon(daemon_base.DaemonBase):
             if thermal_manager:
                 thermal_manager.deinitialize()
         except Exception as e:
-            self.log_error('Caught exception while destroy thermal manager - {}'.format(e))
+            self.log_error('Caught exception while destroy thermal manager - {}'.format(repr(e)))
 
         thermal_monitor.task_stop()
 


### PR DESCRIPTION
Why I did this?

The existing code print exception like:

```python
self.log_error('Caught exception while initializing thermal manager - {}'.format(e))
```

And it would print empty string if the exception class doesn't implement __str__. And the empty string is useless for debugging.

How to fix it?

Always print the exception using repr(e), like:

```python
self.log_error('Caught exception while initializing thermal manager - {}'.format(repr(e)))
```