### PR TITLE
[pmon] Support python3 for xcvrd, psud, thermalctld and syseepromd

### DIFF
--- a/sonic-psud/setup.py
+++ b/sonic-psud/setup.py
@@ -35,6 +35,7 @@ setup(
         'Natural Language :: English',
         'Operating System :: POSIX :: Linux',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.7',
         'Topic :: System :: Hardware',
     ],
     keywords='sonic SONiC psu PSU daemon psud PSUD',

--- a/sonic-syseepromd/setup.py
+++ b/sonic-syseepromd/setup.py
@@ -26,6 +26,7 @@ setup(
         'Natural Language :: English',
         'Operating System :: POSIX :: Linux',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.7',
         'Topic :: System :: Hardware',
     ],
     keywords='sonic SONiC SYSEEPROM syseeprom SYSEEPROMD syseepromd',

--- a/sonic-thermalctld/scripts/thermalctld
+++ b/sonic-thermalctld/scripts/thermalctld
@@ -116,7 +116,7 @@ class FanStatus(logger.Logger):
 
     def _check_speed_value_available(self, speed, target_speed, tolerance, current_status):
         if speed == NOT_AVAILABLE or target_speed == NOT_AVAILABLE or tolerance == NOT_AVAILABLE:
-            if tolerance > 100 or tolerance < 0:
+            if isinstance(tolerance, int) and (tolerance > 100 or tolerance < 0):
                 self.log_warning('Invalid tolerance value: {}'.format(tolerance))
                 return False
 

--- a/sonic-thermalctld/setup.py
+++ b/sonic-thermalctld/setup.py
@@ -34,6 +34,7 @@ setup(
         'Natural Language :: English',
         'Operating System :: POSIX :: Linux',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.7',
         'Topic :: System :: Hardware',
     ],
     keywords='sonic SONiC THERMALCONTROL thermalcontrol THERMALCTL thermalctl thermalctld',

--- a/sonic-xcvrd/setup.py
+++ b/sonic-xcvrd/setup.py
@@ -34,6 +34,7 @@ setup(
         'Natural Language :: English',
         'Operating System :: POSIX :: Linux',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.7',
         'Topic :: System :: Hardware',
     ],
     keywords = 'sonic SONiC TRANSCEIVER transceiver daemon XCVRD xcvrd',

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -22,7 +22,7 @@ try:
     from swsscommon import swsscommon
 
     from .xcvrd_utilities import y_cable_helper
-except ImportError, e:
+except ImportError as e:
     raise ImportError (str(e) + " - required module not found")
 
 #
@@ -1006,7 +1006,7 @@ class SfpStateUpdateTask(object):
                     #   1. the state has been normal before got the event
                     #   2. the state was init and transition to normal after got the event.
                     #      this is for the vendors who don't implement "system_not_ready/system_becom_ready" logic
-                    for key, value in port_dict.iteritems():
+                    for key, value in port_dict.items():
                         logical_port_list = platform_sfputil.get_physical_to_logical(int(key))
                         if logical_port_list is None:
                             helper_logger.log_warning("Got unknown FP port index {}, ignored".format(key))
@@ -1213,7 +1213,7 @@ class DaemonXcvrd(daemon_base.DaemonBase):
                 # For single ASIC platforms we pass port_config_file_path and the asic_inst as 0
                 port_config_file_path = device_info.get_path_to_port_config_file()
                 platform_sfputil.read_porttab_mappings(port_config_file_path, 0)
-        except Exception, e:
+        except Exception as e:
             self.log_error("Failed to read port info: %s" % (str(e)), True)
             sys.exit(PORT_CONFIG_LOAD_ERROR)
 

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
@@ -10,7 +10,7 @@ try:
     from sonic_py_common import multi_asic
     from sonic_y_cable import y_cable
     from swsscommon import swsscommon
-except ImportError, e:
+except ImportError as e:
     raise ImportError(str(e) + " - required module not found")
 
 
@@ -317,7 +317,7 @@ def change_ports_status_for_y_cable_change_event(port_dict, y_cable_presence, st
         port_table_keys[asic_id] = port_tbl[asic_id].getKeys()
 
     # Init PORT_STATUS table if ports are on Y cable and an event is received
-    for key, value in port_dict.iteritems():
+    for key, value in port_dict.items():
         logical_port_list = y_cable_platform_sfputil.get_physical_to_logical(int(key))
         if logical_port_list is None:
             helper_logger.log_warning("Got unknown FP port index {}, ignored".format(key))


### PR DESCRIPTION
Why I did this?

python2 is end of life and SONiC is going to support python3. This PR is to change code in xcvrd, psud, thermalctld and syseeprom to make it compatible with both python3 and python2.

How I did this?

Use tool 2to3 to transfer code

How I verify this?

1. Manual test to make sure all daemons are up and no error logs in syslog
2. Run platform regression test on a few platforms