### PR TITLE
[xcvrd] Fix unit test issue for xcvrd

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -6,7 +6,7 @@ import pytest
 import unittest
 from imp import load_source
 if sys.version_info >= (3, 3):
-    from unittest.mock import MagicMock
+    from unittest.mock import MagicMock, patch
 else:
     from mock import MagicMock, patch
 


### PR DESCRIPTION
Why I did this?

xcvrd unit test failed when building it with python3: 

```
17:23:50  _____________________ ERROR collecting tests/test_xcvrd.py _____________________
17:23:50  tests/test_xcvrd.py:36: in <module>
17:23:50      class TestXcvrdScript(object):
17:23:50  tests/test_xcvrd.py:41: in TestXcvrdScript
17:23:50      @patch('xcvrd.xcvrd.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
17:23:50  E   NameError: name 'patch' is not defined
```

How I did this?
import the package patch

How I test this?

Run build  
