### PR TITLE
[thermalctld] No need exit thermalcltd when loading invalid policy file

### DIFF
--- a/sonic-thermalctld/scripts/thermalctld
+++ b/sonic-thermalctld/scripts/thermalctld
@@ -761,7 +761,6 @@ class ThermalControlDaemon(daemon_base.DaemonBase):
             self.log_warning('Thermal manager is not supported on this platform')
         except Exception as e:
             self.log_error('Caught exception while initializing thermal manager - {}'.format(repr(e)))
-            sys.exit(ERR_INIT_FAILED)
 
     def deinit(self):
         """


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
Currently, when thermalctld loading an invalid policy file, it catches the exception and call sys.exit. However, there is a sub process created and sys.exit cause the daemon hang forever. Actually, it is not necessary to exit thermalctld here because:

1. Other than running thermal policy, there is a sub process which monitoring thermal status. So even if there is an invalid policy file, thermal monitoring can still work.
2. Even if we exit here, supervisord will restart thermalctld and it fall into the same exception again and again. 

#### Motivation and Context
The issue failed a few test cases in test_platform_info.py

#### How Has This Been Tested?
test_platform_info.py

#### Additional Information (Optional)
