### PR TITLE
Enhanced - Handle the error status returned by platform APIs

### DIFF
--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/sfp_status_helper.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/sfp_status_helper.py
@@ -32,7 +32,6 @@ def detect_port_in_error_status(logical_port_name, status_tbl):
     if rec:
         status_dict = dict(fvp)
         error = status_dict.get('error')
-        if SfpBase.SFP_ERROR_DESCRIPTION_BLOCKING in error:
-            return True
+        return SfpBase.SFP_ERROR_DESCRIPTION_BLOCKING in error
     return False
 

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/sfp_status_helper.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/sfp_status_helper.py
@@ -1,35 +1,38 @@
+from sonic_platform_base.sfp_base import SfpBase
+
 # SFP status definition, shall be aligned with the definition in get_change_event() of ChassisBase
 SFP_STATUS_REMOVED = '0'
 SFP_STATUS_INSERTED = '1'
 
 # SFP error code dictinary, new elements can be added if new errors need to be supported.
-SFP_STATUS_ERR_DICT = {
-    2: 'SFP_STATUS_ERR_I2C_STUCK',
-    4: 'SFP_STATUS_ERR_BAD_EEPROM',
-    8: 'SFP_STATUS_ERR_UNSUPPORTED_CABLE',
-    16: 'SFP_STATUS_ERR_HIGH_TEMP',
-    32: 'SFP_STATUS_ERR_BAD_CABLE'
-}
+SFP_ERRORS_BLOCKING_MASK = 0x02
+SFP_ERRORS_GENERIC_MASK = 0x0000FFFE
+SFP_ERRORS_VENDOR_SPECIFIC_MASK = 0xFFFF0000
 
-error_code_block_eeprom_reading = set((error_code for error_code in SFP_STATUS_ERR_DICT.keys()))
-error_str_block_eeprom_reading = set((error for error in SFP_STATUS_ERR_DICT.values()))
+def is_error_block_eeprom_reading(error_bits):
+    return 0 != (error_bits & SFP_ERRORS_BLOCKING_MASK)
 
 
-def is_error_block_eeprom_reading(status):
-    int_status = int(status)
-    for error_code in error_code_block_eeprom_reading:
-        if int_status & error_code:
-            return True
-    return False
+def has_vendor_specific_error(error_bits):
+    return 0 != (error_bits & SFP_ERRORS_VENDOR_SPECIFIC_MASK)
+
+
+def fetch_generic_error_description(error_bits):
+    generic_error_bits = (error_bits & SFP_ERRORS_GENERIC_MASK)
+    error_descriptions = []
+    if generic_error_bits:
+        for error_bit, error_description in SfpBase.SFP_ERROR_BIT_TO_DESCRIPTION_DICT.items():
+            if error_bit & generic_error_bits:
+                error_descriptions.append(error_description)
+    return error_descriptions
 
 
 def detect_port_in_error_status(logical_port_name, status_tbl):
     rec, fvp = status_tbl.get(logical_port_name)
     if rec:
         status_dict = dict(fvp)
-        if 'error' in status_dict:
-            for error in error_str_block_eeprom_reading:
-                if error in status_dict['error']:
-                    return True
+        error = status_dict.get('error')
+        if SfpBase.SFP_ERROR_DESCRIPTION_BLOCKING in error:
+            return True
     return False
 

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py
@@ -419,11 +419,19 @@ def change_ports_status_for_y_cable_change_event(port_dict, y_cable_presence, st
                     helper_logger.log_info("Got SFP inserted event")
                     check_identifier_presence_and_update_mux_table_entry(
                         state_db, port_tbl, y_cable_tbl, static_tbl, mux_tbl, asic_index, logical_port_name, y_cable_presence)
-                elif value == sfp_status_helper.SFP_STATUS_REMOVED or sfp_status_helper.is_error_block_eeprom_reading(value):
+                elif value == sfp_status_helper.SFP_STATUS_REMOVED:
                     check_identifier_presence_and_delete_mux_table_entry(
                         state_db, port_tbl, asic_index, logical_port_name, y_cable_presence, delete_change_event)
 
                 else:
+                    try:
+                        # Now that the value is in bitmap format, let's convert it to number
+                        event_bits = int(value)
+                        if sfp_status_helper.is_error_block_eeprom_reading(event_bits):
+                            check_identifier_presence_and_delete_mux_table_entry(
+                                state_db, port_tbl, asic_index, logical_port_name, y_cable_presence, delete_change_event)
+                    except:
+                        pass
                     # SFP return unkown event, just ignore for now.
                     helper_logger.log_warning("Got unknown event {}, ignored".format(value))
                     continue


### PR DESCRIPTION
In case there is an error returned by platform API
- Translate the error bitmap to error description for generic errors
- Fetch the error description from sfp_error dict or via calling platform API get_error_description for vendor specific errors
- Adjust unit test cases

Signed-off-by: Stephen Sun <stephens@nvidia.com>

<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)
