### PR TITLE
Add speed media key for non CMIS cable

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -660,12 +660,21 @@ class TestXcvrdScript(object):
 
         # Test a good 'specification_compliance' value
         result = media_settings_parser.get_media_settings_key(0, xcvr_info_dict, 100000, 2)
-        assert result == { 'vendor_key': 'MOLEX-1064141421', 'media_key': 'QSFP+-10GBase-SR-255M', 'lane_speed_key': None }
+        assert result == { 'vendor_key': 'MOLEX-1064141421', 'media_key': 'QSFP+-10GBase-SR-255M', 'lane_speed_key': 'speed:50G:2' }
+        
+        # Test a special 'specification_compliance' value
+        specification_compliance_dict = {
+            '10/40G Ethernet Compliance Code': 'Extended',
+            'Extended Specification Compliance': '100GBASE-SR10'
+        }
+        xcvr_info_dict[0]['specification_compliance'] = str(specification_compliance_dict)
+        result = media_settings_parser.get_media_settings_key(0, xcvr_info_dict, 100000, 2)
+        assert result == { 'vendor_key': 'MOLEX-1064141421', 'media_key': 'QSFP+-100GBASE-SR10-255M', 'lane_speed_key': 'speed:50G:2' }
 
         # Test a bad 'specification_compliance' value
         xcvr_info_dict[0]['specification_compliance'] = 'N/A'
         result = media_settings_parser.get_media_settings_key(0, xcvr_info_dict, 100000, 2)
-        assert result == { 'vendor_key': 'MOLEX-1064141421', 'media_key': 'QSFP+-*', 'lane_speed_key': None }
+        assert result == { 'vendor_key': 'MOLEX-1064141421', 'media_key': 'QSFP+-*', 'lane_speed_key': 'speed:50G:2' }
         # TODO: Ensure that error message was logged
 
         mock_is_cmis_api.return_value = True

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/media_settings_parser.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/media_settings_parser.py
@@ -58,6 +58,12 @@ def get_lane_speed_key(physical_port, port_speed, lane_count):
             host_electrical_interface_id = appl_adv_dict[app_id].get('host_electrical_interface_id')
             if host_electrical_interface_id:
                 lane_speed_key = LANE_SPEED_KEY_PREFIX + host_electrical_interface_id.split()[0]
+    else:
+        speed_per_lane = port_speed / 1000 / lane_count
+        speed_per_lane_int = int(speed_per_lane)
+        if speed_per_lane - speed_per_lane_int == 0:
+            speed_per_lane = speed_per_lane_int
+        lane_speed_key = LANE_SPEED_KEY_PREFIX + str(speed_per_lane) + 'G:' + str(lane_count)
 
     return lane_speed_key
 
@@ -88,14 +94,16 @@ def get_media_settings_key(physical_port, transceiver_dict, port_speed, lane_cou
             media_compliance_dict = ast.literal_eval(media_compliance_dict_str)
             if sup_compliance_str in media_compliance_dict:
                 media_compliance_code = media_compliance_dict[sup_compliance_str]
+                if media_compliance_code == 'Extended' or media_compliance_code == 'Unknown':
+                    media_compliance_code = media_compliance_dict['Extended Specification Compliance']
     except ValueError as e:
         helper_logger.log_error("Invalid value for port {} 'specification_compliance': {}".format(physical_port, media_compliance_dict_str))
 
     media_type = transceiver_dict[physical_port]['type_abbrv_name']
 
-    if len(media_type) != 0:
+    if media_type:
         media_key += media_type
-    if len(media_compliance_code) != 0:
+    if media_compliance_code:
         media_key += '-' + media_compliance_code
         sfp = xcvrd.platform_chassis.get_sfp(physical_port)
         api = sfp.get_xcvr_api()


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

There is a function `get_media_settings_key` in `media_settings_parser.py` which is used to extract media setting keys for a given module. The key contains 3 parts: vendor key, media key, speed lane key. 

1. Currently, speed lane key for non CMIS module is always None. For a given module, it could apply different media setting values when it is working on different speed. So, we need to add speed lane key for non CMIS module. 

2. Currently, media key for non CMIS module does not consider the "Extended Specification Compliance". So, the media key could be something like "QSFP+-Extended-255M" or "QSFP+-Unknown-255M", this media key is not good enough. This PR also extends the media key.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

Add media key and speed key for non CMIS cable.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

unit test

#### Additional Information (Optional)
