### PR TITLE
[xcvrd] Optimize module initialization performance

### DIFF
--- a/sonic-xcvrd/tests/mock_swsscommon.py
+++ b/sonic-xcvrd/tests/mock_swsscommon.py
@@ -36,6 +36,12 @@ class Table:
         if key in self.mock_dict:
             return True, self.mock_dict[key]
         return False, None
+    
+    def hget(self, key, field):
+        if key in self.mock_dict:
+            if field in self.mock_dict[key]:
+                return True, self.mock_dict[key][field]
+        return False, None
 
     def get_size(self):
         return (len(self.mock_dict))

--- a/sonic-xcvrd/tests/mock_swsscommon.py
+++ b/sonic-xcvrd/tests/mock_swsscommon.py
@@ -39,8 +39,9 @@ class Table:
     
     def hget(self, key, field):
         if key in self.mock_dict:
-            if field in self.mock_dict[key]:
-                return True, self.mock_dict[key][field]
+            for fv in self.mock_dict[key]:
+                if fv[0] == field:
+                    return True, fv[1]
         return False, None
 
     def get_size(self):

--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -1079,14 +1079,13 @@ class TestXcvrdScript(object):
         del_port_sfp_dom_info_from_db(logical_port_name, port_mapping, [init_tbl, dom_tbl, dom_threshold_tbl, pm_tbl, firmware_info_tbl])
         assert dom_tbl.get_size() == 0
 
-    @pytest.mark.parametrize("mock_found, mock_status_dict, expected_cmis_state", [
-        (True, {'cmis_state': CMIS_STATE_INSERTED}, CMIS_STATE_INSERTED),
-        (False, {}, CMIS_STATE_UNKNOWN),
-        (True, {'other_key': 'some_value'}, CMIS_STATE_UNKNOWN)
+    @pytest.mark.parametrize("mock_found, mock_state, expected_cmis_state", [
+        (True, CMIS_STATE_INSERTED, CMIS_STATE_INSERTED),
+        (False, None, CMIS_STATE_UNKNOWN)
     ])
-    def test_get_cmis_state_from_state_db(self, mock_found, mock_status_dict, expected_cmis_state):
+    def test_get_cmis_state_from_state_db(self, mock_found, mock_state, expected_cmis_state):
         status_tbl = MagicMock()
-        status_tbl.get.return_value = (mock_found, mock_status_dict)
+        status_tbl.hget.return_value = (mock_found, mock_state)
         assert get_cmis_state_from_state_db("Ethernet0", status_tbl) == expected_cmis_state
 
     @patch('xcvrd.xcvrd_utilities.port_event_helper.PortMapping.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
@@ -2264,7 +2263,7 @@ class TestXcvrdScript(object):
         stop_event = threading.Event()
         task = CmisManagerTask(DEFAULT_NAMESPACE, port_mapping, stop_event)
         cfg_port_tbl = MagicMock()
-        cfg_port_tbl.get = MagicMock(return_value=(True, (('laser_freq', 193100),)))
+        cfg_port_tbl.hget = MagicMock(return_value=(True, 193100))
         mock_table_helper.get_cfg_port_tbl = MagicMock(return_value=cfg_port_tbl)
         task.xcvr_table_helper = XcvrTableHelper(DEFAULT_NAMESPACE)
         task.xcvr_table_helper.get_cfg_port_tbl = mock_table_helper.get_cfg_port_tbl
@@ -2276,7 +2275,7 @@ class TestXcvrdScript(object):
         stop_event = threading.Event()
         task = CmisManagerTask(DEFAULT_NAMESPACE, port_mapping, stop_event)
         cfg_port_tbl = MagicMock()
-        cfg_port_tbl.get = MagicMock(return_value=(True, (('tx_power', -10),)))
+        cfg_port_tbl.hget = MagicMock(return_value=(True, -10))
         mock_table_helper.get_cfg_port_tbl = MagicMock(return_value=cfg_port_tbl)
         task.xcvr_table_helper = XcvrTableHelper(DEFAULT_NAMESPACE)
         task.xcvr_table_helper.get_cfg_port_tbl = mock_table_helper.get_cfg_port_tbl


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
1. Use hget instead of hgetall to gain better performance
2. Optimize `SfpStateUpdateTask.init`:
  - Use cache in this function for different logical ports with the same physical module. 
  - Handles transceiver info table and media settings before any other table.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
Improve module initialization performance

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
Manual test

#### Additional Information (Optional)
