### PR TITLE
[xcvrd] do not wait state change while calling cmis.set_lpmode

### DIFF
--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -1268,7 +1268,7 @@ class CmisManagerTask(threading.Thread):
                             continue
 
                         #Sets module to high power mode and doesn't impact datapath if module is already in high power mode
-                        api.set_lpmode(False)
+                        api.set_lpmode(False, wait_state_change = False)
                         self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_AP_CONF)
                         dpDeinitDuration = self.get_cmis_dp_deinit_duration_secs(api)
                         modulePwrUpDuration = self.get_cmis_module_power_up_duration_secs(api)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
Ignore time wait in `cmis.set_lpmode`

#### Motivation and Context
In `CmisManagerTask`, it calls `cmis.set_lpmode` for each logical port. The time wait causes a `wait_time * num_of_logical_port` delay in link up time. The PR is to optimize it.

#### How Has This Been Tested?
Manual test
unit test

#### Additional Information (Optional)
